### PR TITLE
Add cached requirements loader

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -13,7 +13,7 @@ try:
     from rich.markdown import Markdown
 except ImportError:
     Markdown = None
-from py_doctor.utils import logar, esta_em_modo_teste
+from py_doctor.utils import logar, esta_em_modo_teste, load_requirements
 
 console = Console()
 
@@ -33,12 +33,7 @@ def diagnosticar_projeto(caminho_projeto):
         elif escolha == "2":
             req_path = os.path.join(caminho_projeto, "requirements.txt")
             if os.path.exists(req_path):
-                with open(req_path, "r", encoding="utf-8") as f:
-                    requeridos = [
-                        linha.strip()
-                        for linha in f
-                        if linha.strip() and not linha.startswith("#")
-                    ]
+                requeridos = load_requirements(caminho_projeto)
                 verificar_consistencia_requirements(caminho_projeto, requeridos)
             else:
                 console.print("[red]requirements.txt não encontrado.")
@@ -117,10 +112,7 @@ def diagnostico_basico(caminho_projeto):
         logar(log, caminho_projeto, tipo="diagnostico")
         return
 
-    with open(req_path, "r", encoding="utf-8") as f:
-        requeridos = [
-            linha.strip() for linha in f if linha.strip() and not linha.startswith("#")
-        ]
+    requeridos = load_requirements(caminho_projeto)
 
     console.print(
         f"📄 {len(requeridos)} dependência(s) declarada(s) em requirements.txt"
@@ -234,10 +226,7 @@ def atualizar_requirements(projeto_path):
         console.print("[red]❌ requirements.txt não encontrado.")
         return
 
-    with open(req_path, "r", encoding="utf-8") as f:
-        requeridos = [
-            linha.strip() for linha in f if linha.strip() and not linha.startswith("#")
-        ]
+    requeridos = load_requirements(projeto_path)
 
     requeridos_mod = set([r.split("==")[0].split("@")[0].lower() for r in requeridos])
     usados = set()

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,7 @@
 import os
 import datetime
 import configparser
+from functools import lru_cache
 
 LOG_DIR = "logs"
 CONFIG_FILE = ".pydoctor_config"
@@ -47,3 +48,26 @@ def carregar_configuracao():
 def obter_workspace():
     config = carregar_configuracao()
     return os.path.expanduser(config.get("workspace", "~/workspace"))
+
+
+def load_requirements(projeto_path):
+    """Retorna uma lista de dependências do ``requirements.txt`` do projeto.
+
+    O resultado é armazenado em cache e invalidado quando o arquivo é modificado.
+    """
+
+    req_path = os.path.join(projeto_path, "requirements.txt")
+    if not os.path.exists(req_path):
+        return []
+    mtime = os.path.getmtime(req_path)
+    return _load_requirements_cached(req_path, mtime)
+
+
+@lru_cache(maxsize=None)
+def _load_requirements_cached(req_path, _mtime):
+    with open(req_path, "r", encoding="utf-8") as f:
+        return [
+            linha.strip()
+            for linha in f
+            if linha.strip() and not linha.startswith("#")
+        ]


### PR DESCRIPTION
## Summary
- create `load_requirements` utility that caches requirements.txt reading
- use cached loader in `checker.py`

## Testing
- `python __main__.py --help` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685e64f0f08c8324a6d055e4158f6065