### PR TITLE
Add filesystem helpers

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -15,6 +15,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 from py_doctor.checker import diagnosticar_projeto
 from py_doctor.cleaner import limpar_pycache
 from py_doctor.utils import obter_workspace
+from py_doctor import filesystem as fs
 
 console = Console()
 
@@ -44,11 +45,11 @@ def listar_projetos(workspace):
         return []
 
     projetos = []
-    for nome in sorted(os.listdir(pasta_python)):
+    for nome in sorted(fs.list_dir(pasta_python)):
         caminho = os.path.join(pasta_python, nome)
         if not os.path.isdir(caminho):
             continue
-        arquivos = os.listdir(caminho)
+        arquivos = fs.list_dir(caminho)
         if any(f.endswith(".py") for f in arquivos) or "requirements.txt" in arquivos:
             projetos.append(caminho)
 

--- a/checker.py
+++ b/checker.py
@@ -14,6 +14,7 @@ try:
 except ImportError:
     Markdown = None
 from py_doctor.utils import logar, esta_em_modo_teste
+from py_doctor import filesystem as fs
 
 console = Console()
 
@@ -33,12 +34,12 @@ def diagnosticar_projeto(caminho_projeto):
         elif escolha == "2":
             req_path = os.path.join(caminho_projeto, "requirements.txt")
             if os.path.exists(req_path):
-                with open(req_path, "r", encoding="utf-8") as f:
-                    requeridos = [
-                        linha.strip()
-                        for linha in f
-                        if linha.strip() and not linha.startswith("#")
-                    ]
+                conteudo = fs.read_text(req_path, default="")
+                requeridos = [
+                    linha.strip()
+                    for linha in conteudo.splitlines()
+                    if linha.strip() and not linha.startswith("#")
+                ]
                 verificar_consistencia_requirements(caminho_projeto, requeridos)
             else:
                 console.print("[red]requirements.txt não encontrado.")
@@ -62,15 +63,14 @@ def mostrar_ultimo_log(caminho_projeto, tipo="diagnostico"):
 
     ultimo = arquivos[0]
     console.rule(f"📜 Último log de {tipo}")
-    with open(ultimo, "r", encoding="utf-8") as f:
-        conteudo = f.read()
-        if Markdown:
-            console.print(Markdown(conteudo))
-        else:
-            console.print(
-                "[yellow]⚠️ Módulo markdown_it não disponível — exibindo texto puro:"
-            )
-            console.print(conteudo)
+    conteudo = fs.read_text(ultimo, default="")
+    if Markdown:
+        console.print(Markdown(conteudo))
+    else:
+        console.print(
+            "[yellow]⚠️ Módulo markdown_it não disponível — exibindo texto puro:"
+        )
+        console.print(conteudo)
 
 
 # (restante do código permanece igual)
@@ -117,10 +117,10 @@ def diagnostico_basico(caminho_projeto):
         logar(log, caminho_projeto, tipo="diagnostico")
         return
 
-    with open(req_path, "r", encoding="utf-8") as f:
-        requeridos = [
-            linha.strip() for linha in f if linha.strip() and not linha.startswith("#")
-        ]
+    conteudo = fs.read_text(req_path, default="")
+    requeridos = [
+        linha.strip() for linha in conteudo.splitlines() if linha.strip() and not linha.startswith("#")
+    ]
 
     console.print(
         f"📄 {len(requeridos)} dependência(s) declarada(s) em requirements.txt"
@@ -193,15 +193,15 @@ def verificar_consistencia_requirements(projeto_path, requeridos):
             if f.endswith(".py"):
                 caminho = os.path.join(root, f)
                 try:
-                    with open(caminho, "r", encoding="utf-8") as src:
-                        tree = ast.parse(src.read(), filename=caminho)
-                        for node in ast.walk(tree):
-                            if isinstance(node, ast.Import):
-                                for alias in node.names:
-                                    usados.add(alias.name.split(".")[0])
-                            elif isinstance(node, ast.ImportFrom):
-                                if node.module:
-                                    usados.add(node.module.split(".")[0])
+                    codigo = fs.read_text(caminho, default="")
+                    tree = ast.parse(codigo, filename=caminho)
+                    for node in ast.walk(tree):
+                        if isinstance(node, ast.Import):
+                            for alias in node.names:
+                                usados.add(alias.name.split(".")[0])
+                        elif isinstance(node, ast.ImportFrom):
+                            if node.module:
+                                usados.add(node.module.split(".")[0])
                 except Exception as e:
                     console.print(f"[yellow]Aviso: erro ao analisar {caminho}: {e}")
     usados = sorted(usados)
@@ -234,10 +234,10 @@ def atualizar_requirements(projeto_path):
         console.print("[red]❌ requirements.txt não encontrado.")
         return
 
-    with open(req_path, "r", encoding="utf-8") as f:
-        requeridos = [
-            linha.strip() for linha in f if linha.strip() and not linha.startswith("#")
-        ]
+    conteudo = fs.read_text(req_path, default="")
+    requeridos = [
+        linha.strip() for linha in conteudo.splitlines() if linha.strip() and not linha.startswith("#")
+    ]
 
     requeridos_mod = set([r.split("==")[0].split("@")[0].lower() for r in requeridos])
     usados = set()
@@ -246,15 +246,15 @@ def atualizar_requirements(projeto_path):
             if f.endswith(".py"):
                 caminho = os.path.join(root, f)
                 try:
-                    with open(caminho, "r", encoding="utf-8") as src:
-                        tree = ast.parse(src.read(), filename=caminho)
-                        for node in ast.walk(tree):
-                            if isinstance(node, ast.Import):
-                                for alias in node.names:
-                                    usados.add(alias.name.split(".")[0])
-                            elif isinstance(node, ast.ImportFrom):
-                                if node.module:
-                                    usados.add(node.module.split(".")[0])
+                    codigo = fs.read_text(caminho, default="")
+                    tree = ast.parse(codigo, filename=caminho)
+                    for node in ast.walk(tree):
+                        if isinstance(node, ast.Import):
+                            for alias in node.names:
+                                usados.add(alias.name.split(".")[0])
+                        elif isinstance(node, ast.ImportFrom):
+                            if node.module:
+                                usados.add(node.module.split(".")[0])
                 except Exception as e:
                     console.print(f"[yellow]Aviso: erro ao analisar {caminho}: {e}")
 
@@ -272,9 +272,7 @@ def atualizar_requirements(projeto_path):
     if not modo_teste:
         backup = req_path + ".bak"
         os.rename(req_path, backup)
-        with open(req_path, "w", encoding="utf-8") as f:
-            for r in novo_req:
-                f.write(r + "\n")
+        fs.write_text(req_path, "\n".join(novo_req) + "\n")
         console.print(
             f"[green]✔ requirements.txt atualizado com sucesso. Backup salvo como: {backup}"
         )

--- a/cleaner.py
+++ b/cleaner.py
@@ -8,6 +8,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.markdown import Markdown
 from py_doctor.utils import logar, esta_em_modo_teste, LOG_DIR
+from py_doctor import filesystem as fs
 
 console = Console()
 
@@ -25,7 +26,7 @@ def limpar_pycache(projeto_path):
                 removidos.append(("__pycache__", caminho))
                 if not modo_teste:
                     try:
-                        shutil.rmtree(caminho)
+                        fs.remove_path(caminho)
                     except PermissionError as e:
                         console.print(f"[red]Permissão negada ao remover {caminho}: {e}[/]")
                         logar(
@@ -49,7 +50,7 @@ def limpar_pycache(projeto_path):
                 removidos.append((f[-4:], caminho))
                 if not modo_teste:
                     try:
-                        os.remove(caminho)
+                        fs.remove_path(caminho)
                     except PermissionError as e:
                         console.print(f"[red]Permissão negada ao remover {caminho}: {e}[/]")
                         logar(
@@ -105,8 +106,8 @@ def mostrar_ultimo_log(projeto_path, tipo="limpeza"):
 
     ultimo = arquivos[0]
     console.rule(f"📜 Último log de {tipo}")
-    with open(ultimo, "r", encoding="utf-8") as f:
-        console.print(Markdown(f.read()))
+    conteudo = fs.read_text(ultimo, default="")
+    console.print(Markdown(conteudo))
 
 
 def arquivar_logs_antigos(dias):

--- a/filesystem.py
+++ b/filesystem.py
@@ -1,0 +1,64 @@
+import os
+import shutil
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def read_text(path, default=None):
+    """Return the contents of a text file or ``default`` on error."""
+    try:
+        with open(path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except FileNotFoundError:
+        logger.error("File not found: %s", path)
+    except Exception as e:
+        logger.error("Error reading file %s: %s", path, e)
+    return default
+
+
+def write_text(path, text):
+    """Write ``text`` to ``path``. Returns ``True`` if successful."""
+    try:
+        os.makedirs(os.path.dirname(path) or '.', exist_ok=True)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write(text)
+        return True
+    except Exception as e:
+        logger.error("Error writing file %s: %s", path, e)
+        return False
+
+
+def list_dir(path):
+    """Return a list of entries in ``path`` or an empty list on error."""
+    try:
+        return os.listdir(path)
+    except FileNotFoundError:
+        logger.error("Directory not found: %s", path)
+    except Exception as e:
+        logger.error("Error listing directory %s: %s", path, e)
+    return []
+
+
+def remove_path(path):
+    """Remove a file or directory tree. Returns ``True`` if successful."""
+    try:
+        if os.path.isdir(path):
+            shutil.rmtree(path)
+        else:
+            os.remove(path)
+        return True
+    except FileNotFoundError:
+        logger.warning("Path not found for removal: %s", path)
+    except PermissionError as e:
+        logger.error("Permission error removing %s: %s", path, e)
+    except Exception as e:
+        logger.error("Error removing %s: %s", path, e)
+    return False
+
+__all__ = [
+    "read_text",
+    "write_text",
+    "list_dir",
+    "remove_path",
+]


### PR DESCRIPTION
## Summary
- add `filesystem` module for common file operations with basic logging
- refactor `cleaner`, `checker` and `__main__` to use the new helpers

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python __main__.py --help` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685e64f3107083249a29b6100778e2d9