### PR TITLE
Ensure LOG_DIR constant is centralized

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -14,13 +14,12 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 from py_doctor.checker import diagnosticar_projeto
 from py_doctor.cleaner import limpar_pycache
-from py_doctor.utils import obter_workspace
+from py_doctor.utils import obter_workspace, LOG_DIR, garantir_logs
 
 console = Console()
 
 # Início do log de execução
-LOG_DIR = "logs"
-os.makedirs(LOG_DIR, exist_ok=True)
+garantir_logs()
 timestamp = datetime.datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
 log_path = os.path.join(LOG_DIR, f"exec_log_{timestamp}.txt")
 log_file = open(log_path, "w", encoding="utf-8")

--- a/utils.py
+++ b/utils.py
@@ -17,7 +17,6 @@ def timestamp():
 def logar(texto, projeto, tipo="geral", nivel="INFO"):
     """Grava mensagens de log em ``LOG_DIR`` com nivel de severidade."""
 
-    garantir_logs()
     nome_log = f"{tipo}_log_{projeto.replace('/', '_')}_{timestamp()}.txt"
     caminho = os.path.join(LOG_DIR, nome_log)
 


### PR DESCRIPTION
## Summary
- keep the logging directory definition only in `utils`
- use the constant in the CLI entrypoint
- create the log directory once during startup

## Testing
- `python __main__.py --help` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685e64f743cc8324aa4f555f362a64ca