### PR TITLE
Clean up checker by removing placeholder

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -73,9 +73,6 @@ def mostrar_ultimo_log(caminho_projeto, tipo="diagnostico"):
             console.print(conteudo)
 
 
-# (restante do código permanece igual)
-
-
 # def atualizar_requirements(...)
 # def diagnostico_basico(...)
 # def verificar_consistencia_requirements(...)


### PR DESCRIPTION
## Summary
- remove placeholder comment from checker.py

## Testing
- `python __main__.py --help` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685e64f8bf6c83249cd5a7eee57a1aba