### PR TITLE
Fix imports and load requirements

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -15,6 +15,9 @@ from rich.panel import Panel
 from rich.prompt import Prompt
 from rich.table import Table
 
+import py_doctor.filesystem as fs
+from py_doctor.utils import LOG_DIR, garantir_logs, obter_workspace
+
 # Ajuste de path para execução direta (caso rodando fora de pacotes instalados)
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 

--- a/checker.py
+++ b/checker.py
@@ -6,9 +6,13 @@ import os
 import subprocess
 import time
 import ast
+from glob import glob
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
+
+import py_doctor.filesystem as fs
+from py_doctor.utils import LOG_DIR, logar, esta_em_modo_teste
 
 try:
     from rich.markdown import Markdown
@@ -17,6 +21,19 @@ except ImportError:
 
 
 console = Console()
+
+
+def mostrar_ultimo_log(projeto, tipo="geral"):
+    """Exibe o conteúdo do log mais recente para ``projeto``."""
+    padrao = f"{tipo}_log_{projeto.replace('/', '_')}*"
+    arquivos = sorted(glob(os.path.join(LOG_DIR, padrao)))
+    if not arquivos:
+        console.print("[red]Nenhum log encontrado.")
+        return
+    caminho = arquivos[-1]
+    console.rule(f"📝 Último log: {caminho}")
+    texto = fs.read_text(caminho, default="")
+    console.print(texto)
 
 
 def diagnosticar_projeto(caminho_projeto):
@@ -42,7 +59,7 @@ def diagnosticar_projeto(caminho_projeto):
         elif escolha == "2":
             req_path = os.path.join(caminho_projeto, "requirements.txt")
             if os.path.exists(req_path):
-
+                requeridos = fs.read_text(req_path, default="").splitlines()
                 verificar_consistencia_requirements(caminho_projeto, requeridos)
             else:
                 console.print("[red]requirements.txt não encontrado.")
@@ -116,7 +133,7 @@ def diagnostico_basico(caminho_projeto):
         logar(log, caminho_projeto, tipo="diagnostico")
         return
 
-
+    requeridos = fs.read_text(req_path, default="").splitlines()
 
     console.print(
         f"📄 {len(requeridos)} dependência(s) declarada(s) em requirements.txt"
@@ -247,7 +264,7 @@ def atualizar_requirements(projeto_path):
         console.print("[red]❌ requirements.txt não encontrado.")
         return
 
-
+    requeridos = fs.read_text(req_path, default="").splitlines()
     requeridos_mod = set([r.split("==")[0].split("@")[0].lower() for r in requeridos])
     usados = set()
     for root, _, files in os.walk(projeto_path):

--- a/cleaner.py
+++ b/cleaner.py
@@ -9,6 +9,9 @@ from glob import glob
 from rich.console import Console
 from rich.table import Table
 
+import py_doctor.filesystem as fs
+from py_doctor.utils import LOG_DIR, esta_em_modo_teste, logar
+
 
 console = Console()
 

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ import configparser
 
 LOG_DIR = "logs"
 CONFIG_FILE = ".pydoctor_config"
+_CONFIG_CACHE = None
 
 
 def garantir_logs():
@@ -66,7 +67,17 @@ def esta_em_modo_teste():
 
 def carregar_configuracao():
 
+    global _CONFIG_CACHE
+    if _CONFIG_CACHE is not None:
+        return _CONFIG_CACHE
 
+    parser = configparser.ConfigParser()
+    if os.path.exists(CONFIG_FILE):
+        parser.read(CONFIG_FILE, encoding="utf-8")
+        _CONFIG_CACHE = parser["DEFAULT"]
+    else:
+        _CONFIG_CACHE = {}
+    return _CONFIG_CACHE
 
 def reload_config():
     """Força a releitura do arquivo de configuração."""


### PR DESCRIPTION
## Summary
- import filesystem helpers and utils constants
- read `requirements.txt` when checking dependencies
- implement a basic log viewer and configuration loader

## Testing
- `python -m py_compile __main__.py checker.py cleaner.py filesystem.py utils.py`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e70c30ad48324828e2397db0ab546