### PR TITLE
Fix requirement loading

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -10,6 +10,9 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 
+from . import filesystem as fs
+from .utils import esta_em_modo_teste, logar
+
 try:
     from rich.markdown import Markdown
 except ImportError:
@@ -17,6 +20,21 @@ except ImportError:
 
 
 console = Console()
+
+
+def load_requirements(projeto_path: str) -> list[str]:
+    """Read ``requirements.txt`` from ``projeto_path``."""
+    req_file = os.path.join(projeto_path, "requirements.txt")
+    text = fs.read_text(req_file, default="")
+    if not text:
+        return []
+    deps = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        deps.append(line)
+    return deps
 
 
 def diagnosticar_projeto(caminho_projeto):
@@ -42,7 +60,7 @@ def diagnosticar_projeto(caminho_projeto):
         elif escolha == "2":
             req_path = os.path.join(caminho_projeto, "requirements.txt")
             if os.path.exists(req_path):
-
+                requeridos = load_requirements(caminho_projeto)
                 verificar_consistencia_requirements(caminho_projeto, requeridos)
             else:
                 console.print("[red]requirements.txt não encontrado.")
@@ -116,7 +134,7 @@ def diagnostico_basico(caminho_projeto):
         logar(log, caminho_projeto, tipo="diagnostico")
         return
 
-
+    requeridos = load_requirements(caminho_projeto)
 
     console.print(
         f"📄 {len(requeridos)} dependência(s) declarada(s) em requirements.txt"
@@ -247,7 +265,7 @@ def atualizar_requirements(projeto_path):
         console.print("[red]❌ requirements.txt não encontrado.")
         return
 
-
+    requeridos = load_requirements(projeto_path)
     requeridos_mod = set([r.split("==")[0].split("@")[0].lower() for r in requeridos])
     usados = set()
     for root, _, files in os.walk(projeto_path):


### PR DESCRIPTION
## Summary
- read dependencies with a new `load_requirements` helper
- call `load_requirements` when verifying or updating dependencies
- remove references to undefined variable `requeridos`

## Testing
- `python __main__.py -h` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685e70c58d048324b2d9fe3c19e04e7c