### PR TITLE
Fix imports in checker

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -6,10 +6,17 @@ import os
 import subprocess
 import time
 import ast
-from glob import glob
 from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
+
+import py_doctor.filesystem as fs
+from py_doctor.utils import (
+    load_requirements,
+    esta_em_modo_teste,
+    logar,
+    mostrar_ultimo_log,
+)
 
 try:
     from rich.markdown import Markdown


### PR DESCRIPTION
## Summary
- remove unused glob import
- import filesystem and utilities for checker

## Testing
- `python checker.py` *(fails: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_685e878f88c883249b2cdfb7fa1f0e22