### PR TITLE
Fix f-string escape in test

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -51,7 +51,8 @@ def test_log_filename_windows(monkeypatch, tmp_path):
     utils.garantir_logs()
 
     projeto = "dir\\proj"
-    expected = f"geral_log_{projeto.replace('\\', '_')}_ts.txt"
+    safe_proj = projeto.replace("\\", "_")
+    expected = f"geral_log_{safe_proj}_ts.txt"
     expected_path = ntpath.join(str(tmp_path), expected)
     opened = {}
 


### PR DESCRIPTION
## Summary
- use a temporary variable in the Windows log filename test to avoid a backslash escape inside the f-string

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685ec17448888324ba721df60fc5afcf