### PR TITLE
Add default config generation

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -19,7 +19,13 @@ from rich.prompt import Prompt
 from rich.table import Table
 
 import py_doctor.filesystem as fs
-from py_doctor.utils import LOG_DIR, garantir_logs, obter_workspace
+from py_doctor.utils import (
+    LOG_DIR,
+    garantir_logs,
+    obter_workspace,
+    DEFAULT_CONFIG_CREATED,
+    CONFIG_FILE,
+)
 
 from py_doctor.checker import diagnosticar_projeto
 from py_doctor.cleaner import limpar_pycache
@@ -150,6 +156,10 @@ def menu():
     )
 
     workspace = obter_workspace()
+    if DEFAULT_CONFIG_CREATED:
+        console.print(
+            f"[yellow]⚠️ Arquivo de configuração '{CONFIG_FILE}' criado com valores padrão.[/]"
+        )
     console.print(f"[dim]ℹ️ Usando configuração de workspace: {workspace}[/]")
     registrar_log(f"Workspace carregado: {workspace}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -71,3 +71,18 @@ def test_log_filename_windows(monkeypatch, tmp_path):
     caminho = utils.logar("msg", projeto)
     assert caminho == expected_path
     assert opened["path"] == expected_path
+
+
+def test_default_config_created(monkeypatch, tmp_path):
+    cfg_path = tmp_path / ".pydoctor_config"
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setattr(utils, "CONFIG_FILE", str(cfg_path))
+    utils._CONFIG_CACHE = None
+    utils.DEFAULT_CONFIG_CREATED = False
+
+    config = utils.carregar_configuracao()
+    assert utils.DEFAULT_CONFIG_CREATED
+    assert cfg_path.exists()
+    assert config["workspace"] == str(tmp_path)
+    workspace = utils.obter_workspace()
+    assert workspace == str(tmp_path)


### PR DESCRIPTION
## Summary
- generate a default `.pydoctor_config` when missing
- use the current directory as fallback workspace
- notify the user when a default config is created
- test default configuration creation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ec17bc710832486cf107f53d4047a