### PR TITLE
Fix log directory usage in cleaner

### DIFF
--- a/cleaner.py
+++ b/cleaner.py
@@ -127,7 +127,7 @@ def arquivar_logs_antigos(dias):
                 console.print(f"[red]Erro ao arquivar {arquivo}: {e}")
                 logar(
                     f"Erro ao arquivar {arquivo}: {e}",
-                    "logs",
+                    LOG_DIR,
                     tipo="limpeza",
                     nivel="ERROR",
                 )


### PR DESCRIPTION
## Summary
- pass `LOG_DIR` Path to `logar` when logging archive errors

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ce83a45083248d02606cec96423a